### PR TITLE
Exclude Code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ To use deepldoc, follow these instructions:
 
 ### Notes
 
-It is important to specify the correct file path and language. If each is not specified correctly, an error will occur.
-deepldoc translates files with the relevant file extensions and copies files with non-relevant extensions as they are. This preserves the original directory structure.
-deepldoc and deepl will help you with your multilingual projects. Please check it thoroughly and give us feedback if you have any problems.
+- **deepldoc** translates files with the relevant file extensions and copies files with non-relevant extensions as they are. This preserves the original directory structure.
+
+- **deepldoc** preserves code blocks and inline code in your documents. Text wrapped in single (`) or triple backticks (```) will not be translated, ensuring accurate representation of your code samples.
 
 ## How to Download and Run Release Assets
 

--- a/deepldoc/main.go
+++ b/deepldoc/main.go
@@ -54,7 +54,7 @@ func translateAndSaveFile(path, directory, targetLang string) {
 		return
 	}
 
-	translatedContent, err := translator.Translate(string(fileContent), targetLang)
+	translatedContent, err := translator.TranslateTextWithExclusions(string(fileContent), targetLang)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -18,28 +18,28 @@ type DeepLResponse struct {
 }
 
 func TranslateTextWithExclusions(text, targetLang string) (string, error) {
-    re := regexp.MustCompile("(?s)(```.*?```)")
-    parts := re.Split(text, -1)
+	re := regexp.MustCompile("(?s)(`.*?`|```.*?```)")
+	parts := re.Split(text, -1)
 
-    for i, part := range parts {
-        if !strings.HasPrefix(part, "```") {
-            result, err := Translate(part, targetLang)
-            if err != nil {
-                return "", err
-            }
-            parts[i] = result
-        }
-    }
+	for i, part := range parts {
+		if !strings.HasPrefix(part, "`") {
+			result, err := Translate(part, targetLang)
+			if err != nil {
+				return "", err
+			}
+			parts[i] = result
+		}
+	}
 
-    matches := re.FindAllString(text, -1)
+	matches := re.FindAllString(text, -1)
 
-    if len(matches) != 0 {
-        for i, match := range matches {
-            parts = insert(parts, match, 2*i+1)
-        }
-    }
+	if len(matches) != 0 {
+		for i, match := range matches {
+			parts = insert(parts, match, 2*i+1)
+		}
+	}
 
-    return strings.Join(parts, ""), nil
+	return strings.Join(parts, ""), nil
 }
 
 // insert function to add back original code blocks


### PR DESCRIPTION
**deepldoc** preserves code blocks and inline code in your documents. Text wrapped in single (`) or triple backticks (```) will not be translated, ensuring accurate representation of your code samples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced document processing to preserve code blocks and inline code, ensuring accurate representation of code samples during translation.
  
- **Improvements**
  - Improved translation accuracy by excluding text wrapped in single or triple backticks from translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->