### PR TITLE
Translate paragraphs as single lines

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,0 +1,19 @@
+name: go_test
+
+on: [push]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.22
+
+      - name: Test deepldoc
+        run: go test ./deepldoc/...

--- a/deepldoc/deeoldoc_test.go
+++ b/deepldoc/deeoldoc_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestReplaceCodeBlocks(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        string
+		expectedText string
+	}{
+		{
+			name:         "single code block",
+			input:        "```go\nfmt.Println(\"Hello, world!\")\n```",
+			expectedText: "<ignore lang=\"go\">\nfmt.Println(\"Hello, world!\")\n</ignore>",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualText := replaceCodeBlocks(tc.input)
+			if actualText != tc.expectedText {
+				t.Errorf("expected %s, got %s", tc.expectedText, actualText)
+			}
+		})
+	}
+}
+
+func TestRestoreCodeBlocks(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single code block",
+			input:    "<ignore lang=\"go\">\nfmt.Println(\"Hello, world!\")\n</ignore>",
+			expected: "```go\nfmt.Println(\"Hello, world!\")```",
+		},
+		// Add more test cases as needed
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := restoreCodeBlocks(tc.input)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/deepldoc/deeoldoc_test.go
+++ b/deepldoc/deeoldoc_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -21,6 +22,10 @@ func TestWrapCodeBlocks(t *testing.T) {
 			"```python\ndef hello():\n    print(\"Hello, world!\")\n```\n```ruby\nputs \"Hello, world!\"\n```",
 			"<ignore>```python\ndef hello():\n    print(\"Hello, world!\")\n```</ignore>\n<ignore>```ruby\nputs \"Hello, world!\"\n```</ignore>",
 		},
+		{
+			"# ActiveRecord\n\nHello I am\nWorld!\n\n```php+json\n// no translate!\n```\n\n```php\nabc\ndef\nghi\n```\n\n```php\n// no translate!\n```",
+			"# ActiveRecord\n\nHello I am\nWorld!\n\n<ignore>```php+json\n// no translate!\n```</ignore>\n\n<ignore>```php\nabc\ndef\nghi\n```</ignore>\n\n<ignore>```php\n// no translate!\n```</ignore>",
+		},
 	}
 
 	for _, tt := range tests {
@@ -29,6 +34,47 @@ func TestWrapCodeBlocks(t *testing.T) {
 			ans := wrapCodeBlocks(tt.input)
 			if ans != tt.expected {
 				t.Errorf("got %s, want %s", ans, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProcessParagraphs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name: "Test Case 1",
+			input: []string{
+				"This is the first line of the first paragraph.",
+				"This is the second line of the first paragraph.",
+				"",
+				"This is the first line of the second paragraph.",
+			},
+			expected: []string{
+				"This is the first line of the first paragraph. This is the second line of the first paragraph.",
+				"",
+				"This is the first line of the second paragraph.",
+			},
+		},
+		{
+			name: "Test Case 2",
+			input: []string{
+				"This is a single line paragraph.",
+			},
+			expected: []string{
+				"This is a single line paragraph.",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := processParagraphs(tc.input)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("got %v, want %v", got, tc.expected)
 			}
 		})
 	}

--- a/deepldoc/deeoldoc_test.go
+++ b/deepldoc/deeoldoc_test.go
@@ -4,48 +4,31 @@ import (
 	"testing"
 )
 
-func TestReplaceCodeBlocks(t *testing.T) {
-	testCases := []struct {
-		name         string
-		input        string
-		expectedText string
-	}{
-		{
-			name:         "single code block",
-			input:        "```go\nfmt.Println(\"Hello, world!\")\n```",
-			expectedText: "<ignore lang=\"go\">\nfmt.Println(\"Hello, world!\")\n</ignore>",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actualText := replaceCodeBlocks(tc.input)
-			if actualText != tc.expectedText {
-				t.Errorf("expected %s, got %s", tc.expectedText, actualText)
-			}
-		})
-	}
-}
-
-func TestRestoreCodeBlocks(t *testing.T) {
-	testCases := []struct {
-		name     string
+func TestWrapCodeBlocks(t *testing.T) {
+	var tests = []struct {
 		input    string
 		expected string
 	}{
 		{
-			name:     "single code block",
-			input:    "<ignore lang=\"go\">\nfmt.Println(\"Hello, world!\")\n</ignore>",
-			expected: "```go\nfmt.Println(\"Hello, world!\")```",
+			"Here is my code: ```go\nfmt.Println(\"Hello, world!\")\n``` Cool, right?",
+			"Here is my code: <ignore>```go\nfmt.Println(\"Hello, world!\")\n```</ignore> Cool, right?",
 		},
-		// Add more test cases as needed
+		{
+			"No code here!",
+			"No code here!",
+		},
+		{
+			"```python\ndef hello():\n    print(\"Hello, world!\")\n```\n```ruby\nputs \"Hello, world!\"\n```",
+			"<ignore>```python\ndef hello():\n    print(\"Hello, world!\")\n```</ignore>\n<ignore>```ruby\nputs \"Hello, world!\"\n```</ignore>",
+		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := restoreCodeBlocks(tc.input)
-			if actual != tc.expected {
-				t.Errorf("expected %s, got %s", tc.expected, actual)
+	for _, tt := range tests {
+		testname := tt.input
+		t.Run(testname, func(t *testing.T) {
+			ans := wrapCodeBlocks(tt.input)
+			if ans != tt.expected {
+				t.Errorf("got %s, want %s", ans, tt.expected)
 			}
 		})
 	}

--- a/deepldoc/main.go
+++ b/deepldoc/main.go
@@ -55,14 +55,14 @@ func translateAndSaveFile(path, directory, targetLang string) {
 		return
 	}
 
-	replaced := replaceCodeBlocks(string(fileContent))
+	replaced := wrapCodeBlocks(string(fileContent))
 	translatedContent, err := translator.Translate(replaced, targetLang)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return
 	}
 
-	restoredContent := restoreCodeBlocks(translatedContent)
+	restoredContent := removeIgnoreTags(translatedContent)
 
 	relativePath := strings.TrimPrefix(path, directory+string(os.PathSeparator))
 	newPath := filepath.Join(filepath.Dir(directory), targetLang, relativePath)
@@ -97,55 +97,24 @@ func copyFile(path, directory, targetLang string) {
 	}
 }
 
-func replaceCodeBlocks(input string) string {
+func wrapCodeBlocks(input string) string {
 	codeBlockRegex := regexp.MustCompile("(```[\\s\\S]*?```|`.*?`|~~~[\\s\\S]*?~~~)")
 	matches := codeBlockRegex.FindAllString(input, -1)
-
 	for _, match := range matches {
-		lang := ""
-		if strings.HasPrefix(match, "```") || strings.HasPrefix(match, "~~~") {
-			lang = strings.Trim(strings.SplitN(match, "\n", 2)[0], "`~ ")
-		}
-
-		codeContent := strings.TrimPrefix(strings.TrimSuffix(match, "```"), "```"+lang)
-		codeContent = strings.TrimPrefix(strings.TrimSuffix(codeContent, "~~~"), "~~~"+lang)
-		placeholder := "<ignore" + (func() string {
-			if lang != "" {
-				return ` lang="` + lang + `"`
-			}
-			return ""
-		})() + ">" + codeContent + "</ignore>"
-
+		placeholder := "<ignore>" + match + "</ignore>"
 		input = strings.Replace(input, match, placeholder, 1)
 	}
-
 	return input
 }
-func restoreCodeBlocks(text string) string {
-	// Regular expression to match ignore blocks
-	re := regexp.MustCompile("<ignore lang=\"(.*?)\">\\s*(.*?)\\s*</ignore>|<ignore>(.*?)</ignore>")
 
-	// Replace function to change the ignore blocks back to code
-	replacement := func(s string) string {
-		match := re.FindStringSubmatch(s)
+func removeIgnoreTags(input string) string {
+	// Regular expressions that matches <ignore> and </ignore>
+	startTag := regexp.MustCompile("<ignore>")
+	endTag := regexp.MustCompile("</ignore>")
 
-		if len(match) > 2 {
-			lang := match[1]
-			code := match[2]
+	// Replace tags with an empty string
+	input = startTag.ReplaceAllString(input, "")
+	input = endTag.ReplaceAllString(input, "")
 
-			return "```" + lang + "\n" + code + "```"
-		}
-
-		if len(match) > 3 {
-			inlinecode := match[3]
-
-			if inlinecode != "" {
-				return "`" + inlinecode + "`"
-			}
-		}
-
-		return s
-	}
-
-	return re.ReplaceAllStringFunc(text, replacement)
+	return input
 }

--- a/deepldoc/main.go
+++ b/deepldoc/main.go
@@ -153,7 +153,7 @@ func processParagraphs(lines []string) []string {
 }
 
 func wrapCodeBlocks(input string) string {
-	codeBlockRegex := regexp.MustCompile("(```[\\s\\S]*?```|`.*?`|~~~[\\s\\S]*?~~~)")
+	codeBlockRegex := regexp.MustCompile("(```[\\s\\S]*?```|`.*?`|~~~[\\s\\S]*?~~~|\\[[^\\]]*\\]\\([^\\)]*\\))")
 	matches := codeBlockRegex.FindAllString(input, -1)
 	for _, match := range matches {
 		placeholder := "<ignore>" + match + "</ignore>"

--- a/deepldoc/main.go
+++ b/deepldoc/main.go
@@ -109,8 +109,7 @@ func isAlnum(s string) bool {
 
 func isBlockDelimiter(line string) bool {
 	trimmedLine := strings.TrimSpace(line)
-	isDelimeter := trimmedLine == "```" || trimmedLine == "~~~" || trimmedLine == "<ignode>" || trimmedLine == "</ignode>"
-
+	isDelimeter := trimmedLine == "```" || trimmedLine == "~~~" || trimmedLine == "<ignore>" || trimmedLine == "</ignore>"
 	return isDelimeter
 }
 

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -1,4 +1,5 @@
 package translator
+
 import (
 	"bytes"
 	"encoding/json"
@@ -43,16 +44,20 @@ func TranslateTextWithExclusions(text, targetLang string) (string, error) {
 }
 
 // insert function to add back original code blocks
-func insert(slice []string, element string, index int) []string{
-    slice = append(slice, "")
-    copy(slice[index+1:], slice[index:])
-    slice[index] = element
-    return slice
+func insert(slice []string, element string, index int) []string {
+	slice = append(slice, "")
+	copy(slice[index+1:], slice[index:])
+	slice[index] = element
+	return slice
 }
 
 // Translation function
 func Translate(text string, targetLang string) (string, error) {
 	apiKey := os.Getenv("DEEPL_API_KEY") // Load the DeepL API key from environment variables
+	if apiKey == "" {
+		fmt.Println("API key is empty. Please set the DEEPL_API_KEY environment variable.")
+		os.Exit(1)
+	}
 	url := "https://api-free.deepl.com/v2/translate"
 	// Create request body
 	reqBody, err := json.Marshal(map[string]interface{}{

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -3,6 +3,7 @@ package translator
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -55,8 +56,7 @@ func insert(slice []string, element string, index int) []string {
 func Translate(text string, targetLang string) (string, error) {
 	apiKey := os.Getenv("DEEPL_API_KEY") // Load the DeepL API key from environment variables
 	if apiKey == "" {
-		fmt.Println("API key is empty. Please set the DEEPL_API_KEY environment variable.")
-		os.Exit(1)
+		return "", errors.New("API key is empty. Please set the DEEPL_API_KEY environment variable.")
 	}
 	url := "https://api-free.deepl.com/v2/translate"
 	// Create request body

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -61,8 +61,10 @@ func Translate(text string, targetLang string) (string, error) {
 	url := "https://api-free.deepl.com/v2/translate"
 	// Create request body
 	reqBody, err := json.Marshal(map[string]interface{}{
-		"text":        []string{text},
-		"target_lang": targetLang,
+		"text":         []string{text},
+		"target_lang":  targetLang,
+		"tag_handling": "xml",
+		"ignore_tags":  []string{"ignore"}, // pass array of strings
 	})
 	if err != nil {
 		return "", err

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"regexp"
-	"strings"
 )
 
 // Structure of DeepL API response
@@ -17,39 +15,6 @@ type DeepLResponse struct {
 	Translations []struct {
 		Text string `json:"text"`
 	} `json:"translations"`
-}
-
-func TranslateTextWithExclusions(text, targetLang string) (string, error) {
-	re := regexp.MustCompile("(?s)(`.*?`|```.*?```)")
-	parts := re.Split(text, -1)
-
-	for i, part := range parts {
-		if !strings.HasPrefix(part, "`") {
-			result, err := Translate(part, targetLang)
-			if err != nil {
-				return "", err
-			}
-			parts[i] = result
-		}
-	}
-
-	matches := re.FindAllString(text, -1)
-
-	if len(matches) != 0 {
-		for i, match := range matches {
-			parts = insert(parts, match, 2*i+1)
-		}
-	}
-
-	return strings.Join(parts, ""), nil
-}
-
-// insert function to add back original code blocks
-func insert(slice []string, element string, index int) []string {
-	slice = append(slice, "")
-	copy(slice[index+1:], slice[index:])
-	slice[index] = element
-	return slice
 }
 
 // Translation function


### PR DESCRIPTION
before

```
Hello, I am
World
```

after

```
Hello I am a World.
```

Translate paragraphs as single lines but other lines stay same.

これはややこしい問題で、DeepLのアプリケーションでもうまく解決できていない。しかしmdファイルに特化したdeepldocでは、記号ではない文字で始まり空行で挟まれている連結した行を１パラグラフとして、改行を削除して１行に変換。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a GitHub Actions workflow for running tests on the Go project.
  - Enhanced the translation process by adding functions to handle and process paragraphs, wrap code blocks, and remove specific tags.

- **Bug Fixes**
  - Improved error handling for empty API keys in the translation module.

- **Tests**
  - Added new test functions to verify the handling of code blocks and paragraphs in the document processing module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->